### PR TITLE
Add zero line to ssff track displays

### DIFF
--- a/app/schemaFiles/emuwebappConfigSchema.json
+++ b/app/schemaFiles/emuwebappConfigSchema.json
@@ -258,7 +258,7 @@
 										},
 										"displayLine": {
 											"type": "boolean"
-										},
+										}
 									},
 									"required": ["signalCanvasName", "ssffTrackName"],
 									"additionalProperties": false

--- a/app/schemaFiles/emuwebappConfigSchema.json
+++ b/app/schemaFiles/emuwebappConfigSchema.json
@@ -248,6 +248,22 @@
 									"additionalProperties": false
 								}
 							},
+							"zeroLine": {
+								"type": "array",
+								"items": {
+									"type" : "object",
+									"properties": {
+										"ssffTrackName": {
+											"type": "string"
+										},
+										"displayLine": {
+											"type": "boolean"
+										},
+									},
+									"required": ["signalCanvasName", "ssffTrackName"],
+									"additionalProperties": false
+								}
+							},
 							"contourLims": {
 								"type": "array",
 								"items": {

--- a/app/scripts/directives/drawssff.js
+++ b/app/scripts/directives/drawssff.js
@@ -161,6 +161,24 @@ angular.module('emuwebApp')
 					var nrOfSamples = colEndSampleNr - colStartSampleNr;
 					var curSampleArrs = col.values.slice(colStartSampleNr, colStartSampleNr + nrOfSamples);
 
+					// draw zero line
+					var drawZeroLine = ConfigProviderService.getZeroLineOfTrack(scope.trackName).displayLine;
+					if (drawZeroLine == "undefined") {
+					  drawZeroLine = false;
+					}
+					if (drawZeroLine === true) {
+						ctx.beginPath();
+					 	ctx.lineWidth = "2";
+            				  	ctx.strokeStyle = "blue";
+            				  	ctx.globalAlpha = 0.75;
+            				  	var zeroY = canvas.height - ((0 - minVal) / (maxVal - minVal) * canvas.height);
+            				  	ctx.moveTo(0, zeroY);
+            				  	ctx.lineTo(10000, zeroY);
+            				  	ctx.stroke();
+            				  	ctx.lineWidth = "1";
+            				  	ctx.globalAlpha = 1;
+					}
+
 					if (nrOfSamples < canvas.width && nrOfSamples >= 2) {
 
 						var x, y, curSampleInCol, curSampleInColTime;

--- a/app/scripts/services/ConfigProviderService.js
+++ b/app/scripts/services/ConfigProviderService.js
@@ -10,7 +10,7 @@ angular.module('emuwebApp')
 		sServObj.curDbConfig = {};
 		sServObj.initDbConfig = {};
 
-		// embedded values -> if these are set this overrides the normal config  
+		// embedded values -> if these are set this overrides the normal config
 		sServObj.embeddedVals = {
 			audioGetUrl: '',
 			labelGetUrl: '',
@@ -50,14 +50,14 @@ angular.module('emuwebApp')
 				});
 			}
 		};
-		
+
 		sServObj.getDelta = function (current) {
 			var defer = $q.defer();
 			var ret = sServObj.getDeltas(current, sServObj.initDbConfig);
 			defer.resolve(ret);
 			return defer.promise;
 		};
-		
+
 		sServObj.getDeltas = function (current, start) {
 			var ret = {};
 			angular.forEach(current, function (value, key) {
@@ -74,12 +74,12 @@ angular.module('emuwebApp')
 						if(key !== 'clear' && key !== 'openDemoDB' && key !== 'specSettings') {
 							ret[key] = value;
 						}
-						
+
 					}
 				}
 			});
 			return ret;
-		};		
+		};
 
 		/**
 		 *
@@ -109,6 +109,19 @@ angular.module('emuwebApp')
 
             return res;
         };
+
+		/**
+		 *
+		 */
+		sServObj.getZeroLineOfTrack = function (trackName) {
+			var res = {};
+			angular.forEach(sServObj.vals.perspectives[viewState.curPerspectiveIdx].signalCanvases.zeroLine, function (vL) {
+				if (vL.ssffTrackName === trackName) {
+					res = vL;
+				}
+			});
+			return res;
+		};
 
 		/**
 		 *


### PR DESCRIPTION
Draw zero line only if configured.

Zero line is useful for visual inspection of velocity tracks. It's a feature needed at IfL Phonetik Cologne.

Configuration looks roughly like this:
"perspectives": [
      {
        ...,
          "zeroLine": [
            {
              "ssffTrackName": "mytrack",
              "displayLine": true
            }
          ],
          ...
        },
        ...      
     }
]