### PR TITLE
Fix for canvas minmaxlims

### DIFF
--- a/src/app/components/signal-canvas-markup-canvas.component.ts
+++ b/src/app/components/signal-canvas-markup-canvas.component.ts
@@ -282,38 +282,57 @@ let SignalCanvasMarkupCanvasComponent = {
         private drawMarkup () {
             this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
             // draw current viewport selected
+            var minVal = 0;
+            var maxVal = 0;
+	        var unit = '';	
             if (this.trackName === 'OSCI') {
                 this.DrawHelperService.drawViewPortTimes(this.ctx, true);
                 this.DrawHelperService.drawCurViewPortSelected(this.ctx, true);
             } else if (this.trackName === 'SPEC') {
+                minVal = this.ViewStateService.spectroSettings.rangeFrom;
+                maxVal = this.ViewStateService.spectroSettings.rangeTo;
+		        unit = 'Hz';
                 this.DrawHelperService.drawCurViewPortSelected(this.ctx, false);
                 this.DrawHelperService.drawMinMaxAndName(
                     this.ctx, 
                     '', 
-                    this.ViewStateService.spectroSettings.rangeFrom, 
-                    this.ViewStateService.spectroSettings.rangeTo, 
+                    minVal, 
+                    maxVal, 
                     2);
             } else {
                 var tr = this.ConfigProviderService.getSsffTrackConfig(this.trackName);
-                var col = this.SsffDataService.getColumnOfTrack(tr.name, tr.columnName);
+                var minMaxValLims = this.ConfigProviderService.getValueLimsOfTrack(this.trackName); 
+		        if(!angular.equals(minMaxValLims, {})){
+			        minVal = minMaxValLims.minVal;
+			        maxVal = minMaxValLims.maxVal;
+			        if(minMaxValLims.unit !== undefined){
+				        unit = minMaxValLims.unit;
+			        }
+		        } else {
+			        var col = this.SsffDataService.getColumnOfTrack(tr.name, tr.columnName);
+			        if(typeof col !== "undefined"){
+                        minVal = col._minVal;
+                    	maxVal = col._maxVal;
+			    }
+		    }
                 this.DrawHelperService.drawCurViewPortSelected(this.ctx, false);
-                if(typeof col !== "undefined"){
+                if(maxVal > 0){
                     this.DrawHelperService.drawMinMaxAndName(
                         this.ctx, 
                         this.trackName, 
-                        col._minVal, 
-                        col._maxVal, 
+                        minVal, 
+                        maxVal, 
                         2);
                 }
             }
             if(this.drawCrossHairs){
-                this.DrawHelperService.drawCrossHairs(
+		this.DrawHelperService.drawCrossHairs(
                     this.ctx, 
                     this.curMouseX,
                     this.curMouseY, 
-                    this.ViewStateService.spectroSettings.rangeFrom, 
-                    this.ViewStateService.spectroSettings.rangeTo, 
-                    'Hz', 
+                    minVal, 
+                    maxVal, 
+                    unit, 
                     this.trackName);
             } else {
                 this.DrawHelperService.drawCrossHairX(this.ctx, this.curMouseX);

--- a/src/app/services/draw-helper.service.ts
+++ b/src/app/services/draw-helper.service.ts
@@ -722,40 +722,35 @@ class DrawHelperService{
 					ctx.stroke();
 				} else {
 					// draw min max an name of track
-					var tr = this.ConfigProviderService.getSsffTrackConfig(trackname);
-					var col = this.SsffDataService.getColumnOfTrack(tr.name, tr.columnName);
-
-					if(typeof col !== "undefined"){
-						mouseFreq = col._maxVal - (mouseY / ctx.canvas.height * (col._maxVal - col._minVal));
-						mouseFreq = this.MathHelperService.roundToNdigitsAfterDecPoint(mouseFreq, 2); // crop
-						this.FontScaleService.drawUndistortedText(
-							ctx, 
-							mouseFreq, 
-							fontSize, 
-							styles.fontSmallFamily, 
-							5, 
-							y, 
-							styles.colorTransparentRed, 
-							true);
-						this.FontScaleService.drawUndistortedText(
-							ctx, 
-							mouseFreq, 
-							fontSize, 
-							styles.fontSmallFamily, 
-							ctx.canvas.width - 5 - tW, 
-							y, 
-							styles.colorTransparentRed, 
-							true);
-						ctx.beginPath();
-						ctx.moveTo(0, mouseY);
-						ctx.lineTo(5, mouseY + 5);
-						ctx.moveTo(0, mouseY);
-						ctx.lineTo(ctx.canvas.width, mouseY);
-						ctx.lineTo(ctx.canvas.width - 5, mouseY + 5);
-						ctx.moveTo(mouseX, 0);
-						ctx.lineTo(mouseX, ctx.canvas.height);
-						ctx.stroke();
-					}
+					mouseFreq = max - (mouseY / ctx.canvas.height * (max - min));
+					mouseFreq = this.MathHelperService.roundToNdigitsAfterDecPoint(mouseFreq, 2); // crop
+					this.FontScaleService.drawUndistortedText(
+						ctx, 
+						mouseFreq + unit, 
+						fontSize, 
+						styles.fontSmallFamily, 
+						5, 
+						y, 
+						styles.colorTransparentRed, 
+						true);
+					this.FontScaleService.drawUndistortedText(
+						ctx, 
+						mouseFreq + unit,  
+						fontSize, 
+						styles.fontSmallFamily, 
+						ctx.canvas.width - 5 - tW, 
+						y, 
+						styles.colorTransparentRed, 
+						true);
+					ctx.beginPath();
+					ctx.moveTo(0, mouseY);
+					ctx.lineTo(5, mouseY + 5);
+					ctx.moveTo(0, mouseY);
+					ctx.lineTo(ctx.canvas.width, mouseY);
+					ctx.lineTo(ctx.canvas.width - 5, mouseY + 5);
+					ctx.moveTo(mouseX, 0);
+					ctx.lineTo(mouseX, ctx.canvas.height);
+					ctx.stroke();
 				}
 			}
 			this.FontScaleService.drawUndistortedTextTwoLines(

--- a/src/testData/newFormat/ae/ae_DBconfig.json
+++ b/src/testData/newFormat/ae/ae_DBconfig.json
@@ -154,7 +154,8 @@
 				"minMaxValLims":[{
 					"ssffTrackName": "fundFreq",
 					"minVal": 0,
-					"maxVal": 200
+					"maxVal": 200,
+					"unit": "Hz"
 				}],
 				"horizontalLines": [{
                     "ssffTrackName": "fundFreq",


### PR DESCRIPTION
Fix for issue #296 - cross hair reports correct value when min & max limits are set for a SSFF track in the _DBconfig.json.

Feature: added the ability to set the unit text in the _DBconfig.json, see example in: 
https://github.com/IPS-LMU/EMU-webApp/blob/master/src/testData/newFormat/ae/ae_DBconfig.json