### PR TITLE
preserve files and options using window messaging

### DIFF
--- a/iframe-demo/index.html
+++ b/iframe-demo/index.html
@@ -66,17 +66,21 @@
         }
     </style>
     <script type="module">
-        const emuWebAppURL = "http://localhost:9000/";
+        const emuWebAppURL = "http://127.0.0.1:9000/";
+        let iframeLoaded = false;
 
         const options = {
           disableBundleListSidebar: true,
           saveToWindowParent: true,
-          audioGetUrl: "http://localhost:7283/msajc003.wav",
-          labelGetUrl:  "http://localhost:7283/msajc003_annot.json",
-          labelType: "annotJSON"
-        }
+          labelType: "annotJSON",
+          listenForMessages: false,
+        };
 
-        let iframe, applyButton, disableBundleListSidebarOption, saveToWindowParentOption, labelTypeOption;
+        const audioGetUrl = "http://127.0.0.1:7283/msajc003.wav";
+        const labelGetUrl = "http://127.0.0.1:7283/msajc003_annot.json";
+
+        let audioFileBuffer, annotation;
+        let iframe, applyButton, disableBundleListSidebarOption, saveToWindowParentOption, labelTypeOption, audioFileOption, transcriptFileOption, listenForMessagesOption;
 
         /**
          * returns a string representing query parameters and their values without empty values.
@@ -95,7 +99,7 @@
               if (typeof value !== 'string' && Array.isArray(value)) {
                 value = value.join(',');
               }
-              if (typeof value == 'boolean' && value == false) {
+              if (typeof value == 'boolean' && value === false) {
                 continue;
               }
               strArray.push(`${key}=${encodeURIComponent(value)}`);
@@ -109,10 +113,22 @@
           options.disableBundleListSidebar = disableBundleListSidebarOption.checked;
           options.saveToWindowParent = saveToWindowParentOption.checked;
           options.labelType = labelTypeOption.value;
-          iframe.src = `${emuWebAppURL}${stringifyQueryParams(options)}`;
+
+          if (!iframeLoaded) {
+            iframe.removeEventListener("load", onIFrameLoaded);
+            iframe.addEventListener("load", onIFrameLoaded);
+            iframe.src = `${emuWebAppURL}${stringifyQueryParams(!options.listenForMessages ? {
+              ...options,
+              audioGetUrl,
+              labelGetUrl
+            } : {listenForMessages: true})}`;
+          } else {
+            sendOptionsToIFrame();
+          }
         }
 
         function onWindowMessageRetrieved(event) {
+          console.log(event);
           if (event?.data) {
             // valid data object
             console.log(`----\n${new Date().toLocaleString()}: Received new data from iframe:`);
@@ -131,15 +147,81 @@
           // options
           disableBundleListSidebarOption = document.getElementById("disableBundleListSidebarOption");
           disableBundleListSidebarOption.checked = options.disableBundleListSidebar;
+
           saveToWindowParentOption = document.getElementById("saveToWindowParentOption");
           saveToWindowParentOption.checked = options.saveToWindowParent;
+
           labelTypeOption = document.getElementById("labelTypeOption");
           labelTypeOption.value = options.labelType;
+
+          audioFileOption = document.getElementById("audioFileOption");
+          audioFileOption.addEventListener("change", onAudioFileChange);
+
+          transcriptFileOption = document.getElementById("transcriptFileOption");
+          transcriptFileOption.addEventListener("change", onTranscriptFileChange);
+
+          listenForMessagesOption = document.getElementById("listenForMessagesOption");
+          listenForMessagesOption.addEventListener("change", onListenForMessagesOptionChange);
+        }
+
+        function onListenForMessagesOptionChange(event) {
+          iframeLoaded = false;
+          options.listenForMessages = event.target.checked;
+          const fileInputs = document.getElementById("fileInputs");
+          fileInputs.style.display = event.target.checked ? "block" : "none";
         }
 
         function afterDocumentLoaded() {
           initialize();
           applyOptions();
+        }
+
+        function onIFrameLoaded() {
+          setTimeout(() => {
+            sendOptionsToIFrame();
+            iframeLoaded = true;
+          }, 1000)
+        }
+
+        function sendOptionsToIFrame(){
+          iframe.contentWindow.postMessage({
+            type: "command",
+            command: "load",
+            params: options,
+            audioArrayBuffer: audioFileBuffer,
+            annotation: annotation
+          }, "*");
+        }
+
+        async function onAudioFileChange(event) {
+          const file = event.target.files[0];
+          audioFileBuffer = await readFile(file, "arraybuffer");
+        }
+
+        async function onTranscriptFileChange(event) {
+          const file = event.target.files[0];
+          const annotJSONText = await readFile(file, "text");
+          try {
+            annotation = JSON.parse(annotJSONText);
+          } catch(e){
+            alert("Invalid JSON file");
+            console.error(e);
+          }
+        }
+
+        async function readFile(blob, type){
+          return new Promise(function(resolve,reject){
+            const reader = new FileReader();
+            reader.addEventListener("load", function(){
+              resolve(reader.result);
+            });
+            reader.addEventListener("error", reject);
+            if (type === "text") {
+              reader.readAsText(blob, "utf-8");
+            } else {
+              reader.readAsArrayBuffer(blob);
+            }
+          });
         }
 
         window.addEventListener("load", afterDocumentLoaded);
@@ -160,6 +242,19 @@
             <div class="option">
                 <label for="labelTypeOption" style="display: block;">Label type:</label>
                 <input type="text" id="labelTypeOption" placeholder="label type"/>
+            </div>
+            <div class="option">
+                <label for="listenForMessagesOption">Listen for messages</label> <input type="checkbox" id="listenForMessagesOption"/>
+            </div>
+            <div id="fileInputs" style="display:none;">
+                <div class="option">
+                    <label for="audioFileOption" style="display: block;">Audio file:</label>
+                    <input type="file" id="audioFileOption"/>
+                </div>
+                <div class="option">
+                    <label for="transcriptFileOption" style="display: block;">Transcript file:</label>
+                    <input type="file" id="transcriptFileOption"/>
+                </div>
             </div>
         </div>
         <button id="applyButton">Apply</button>

--- a/src/app/components/emu-webapp.component.ts
+++ b/src/app/components/emu-webapp.component.ts
@@ -701,7 +701,7 @@ let EmuWebAppComponent = {
                     validRes = this.ValidationService.validateJSO('DBconfigFileSchema', this.ConfigProviderService.curDbConfig);
 
                     if (validRes === true) {
-                        if(this.ConfigProviderService.embeddedVals.saveToWindowParent === "true"){
+                        if(this.ConfigProviderService.embeddedVals.saveToWindowParent) {
                             this.ConfigProviderService.vals.activeButtons.saveBundle = true;
                         }
                         var bndlList = [{'session': 'File(s)', 'name': 'from URL parameters'}];

--- a/src/app/services/config-provider.service.ts
+++ b/src/app/services/config-provider.service.ts
@@ -24,7 +24,9 @@ class ConfigProviderService {
 			audioGetUrl: '',
 			labelGetUrl: '',
 			labelType: '',
-			fromUrlParams: false
+			fromUrlParams: false,
+            listenForMessages: false,
+            saveToWindowParent: false
 		};
 	}
 	/**

--- a/src/app/services/io-handler.service.ts
+++ b/src/app/services/io-handler.service.ts
@@ -361,7 +361,18 @@ class IoHandlerService{
 	// }
 	
 	return getProm;
-};	
+};
+
+
+public listenForMessages(callback){
+    this.onMessageCallback = callback;
+    window.addEventListener("message", this.onMessage);
+}
+
+private onMessageCallback = (event) => {};
+private onMessage = (event) =>{
+    this.onMessageCallback(event);
+}
 
 
 /**
@@ -393,8 +404,8 @@ public parseLabelFile(string, annotates, name, fileType) {
 		prom = this.TextGridParserService.asyncParseTextGrid(string, this.ConfigProviderService.embeddedVals.labelGetUrl, 'embeddedTEXTGRID');
 	} else if (fileType === 'annotJSON') {
 		var def = this.$q.defer();
-		prom = def.promise;
 		def.resolve(angular.fromJson(string));
+        prom = def.promise;
 	}
 	
 	return prom;


### PR DESCRIPTION
This feature allows to send files and parameters from parent window to the Emu webApp if a query parameter `listenForMessages=true` is set. AudioFile as Arraybuffer, Annotation as JSON or text.`listenForMessages` is optional.

**Advantages:**
- Options are not disclosed on the URL. Only `listenForMessages=true` is visible.
- Files don't be available via URL to make them available on the Emu-webApp
- Options for the Emu WebApp may change without reloading the whole Emu-webApp page