### PR TITLE
fix audioGetUrl not working without labelGetUrl in load command

### DIFF
--- a/src/app/components/emu-webapp.component.ts
+++ b/src/app/components/emu-webapp.component.ts
@@ -683,7 +683,7 @@ let EmuWebAppComponent = {
                             }
 
                             Promise.all(promises).then((data) => {
-                                this.readAudioOrBundleData(data[0], searchObject, data[1].data);
+                                this.readAudioOrBundleData(data[0], searchObject, data.length > 1 ? data[1].data: undefined);
                             }, (errMess) => {
                                 this.ModalService.open('views/error.html', 'Could not get audio file:' + this.ConfigProviderService.embeddedVals.audioGetUrl + ' ERROR: ' + JSON.stringify(errMess, null, 4));
                             });


### PR DESCRIPTION
Emu-webApp does not load the audio from a given `audioGetUrl` in params of the load command if no `labelGetUrl` has been set. This is a small fix.