### PR TITLE
Missing "annotates" when parsing TextGrid in "listenForMessage" mode

### DIFF
--- a/src/app/components/emu-webapp.component.ts
+++ b/src/app/components/emu-webapp.component.ts
@@ -659,6 +659,7 @@ let EmuWebAppComponent = {
                         const command = event.data as WindowMessageCommandLoad;
                         this.ConfigProviderService.embeddedVals.labelType = command.params.labelType ?? this.ConfigProviderService.embeddedVals.labelType;
                         this.ConfigProviderService.embeddedVals.saveToWindowParent = command.params.saveToWindowParent ?? this.ConfigProviderService.embeddedVals.saveToWindowParent;
+                        this.ConfigProviderService.embeddedVals.labelGetUrl = command.params.labelGetUrl;
                         this.ViewStateService.bundleListSideBarDisabled = command.params.disableBundleListSidebar ?? false;
 
                         if (command.params.audioArrayBuffer) {
@@ -678,8 +679,7 @@ let EmuWebAppComponent = {
                             }
 
                             if (command.params.labelGetUrl) {
-                                this.ConfigProviderService.embeddedVals.labelGetURL = command.params.labelGetUrl;
-                                promises.push(this.IoHandlerService.httpGetPath(this.ConfigProviderService.embeddedVals.labelGetURL, "application/json"));
+                                promises.push(this.IoHandlerService.httpGetPath(this.ConfigProviderService.embeddedVals.labelGetUrl, "application/json"));
                             }
 
                             Promise.all(promises).then((data) => {

--- a/src/app/components/emu-webapp.component.ts
+++ b/src/app/components/emu-webapp.component.ts
@@ -904,11 +904,12 @@ let EmuWebAppComponent = {
 
                 }
 
-                this.ViewStateService.setCurLevelAttrDefs(this.ConfigProviderService.curDbConfig.levelDefinitions);
-
-                this.ViewStateService.somethingInProgressTxt = 'Done!';
-                this.ViewStateService.somethingInProgress = false;
-                this.ViewStateService.setState('labeling');
+                this.$timeout(()=> {
+                    this.ViewStateService.setCurLevelAttrDefs(this.ConfigProviderService.curDbConfig.levelDefinitions);
+                    this.ViewStateService.somethingInProgressTxt = 'Done!';
+                    this.ViewStateService.somethingInProgress = false;
+                    this.ViewStateService.setState('labeling');
+                })
 
             }, function (errMess) {
                 this.ModalService.open('views/error.html', 'Error parsing wav file: ' + errMess.status.message);


### PR DESCRIPTION
If `listenForMessages` is used it was not possible to parse a textgrid annotation to annotJSON because of the missing labelGetUrl.

Is it intended that `labelGetUrl` does play a role for writing the `annotates` field of an AnnotJSON? As far as I know the `annotates` field should contain the audio file name it's referenced to? Is it even allowed to set an URL to the annotates field?